### PR TITLE
백준 - N과 M(3) (15651)

### DIFF
--- a/35주차/서민주/NAndM3.swift
+++ b/35주차/서민주/NAndM3.swift
@@ -1,0 +1,17 @@
+let NM = readLine()!.split(separator: " ").map{ Int(String($0))! }
+let (N, M) = (NM[0], NM[1])
+var result = ""
+
+func dfs(_ count: Int, _ sequence: String) {
+    guard count < M else { 
+        result += "\(sequence)\n"
+        return
+    }
+
+    for n in 1...N {
+        dfs(count + 1, sequence + "\(n) ")
+    }
+}
+
+dfs(0, "")
+print(result)


### PR DESCRIPTION
- Backtracking
- '**같은 수를 여러 번 골라도 된다.**' 는 조건
  -  #130 N과 M(1) 문제와 유사하나, `contains(...)`조건을 삭제
  - `[Int]`배열에 담아 `String`으로 바꿔주는 방식은 시간초과, 
  `String`을 파라미터로 넘겨줘 그때 그때 print하는 방식은 메모리초과
    - `String`을 파라미터로 넘기되, `result: String`에 한 줄씩 담아놓고 마지막에 한번에 print 해서 해결
  - 배열이 아닌 `String`을 넘겨, 수열에 수가 몇 개 포함되었는지 확인 불가
    - `count: Int` 파라미터 추가