### PR TITLE
백준 - N과 M(4) (15652)

### DIFF
--- a/35주차/서민주/NAndM4.swift
+++ b/35주차/서민주/NAndM4.swift
@@ -1,0 +1,18 @@
+let NM = readLine()!.split(separator: " ").map{ Int(String($0))! }
+let (N, M) = (NM[0], NM[1])
+var result = ""
+
+func dfs(_ num: Int, _ count: Int, _ sequence: String) {
+    guard count < M else { 
+        result += "\(sequence)\n"
+        return
+    }
+    guard num <= N else { return }
+
+    for n in num...N {
+        dfs(n, count + 1, sequence + "\(n) ")
+    }
+}
+
+dfs(1, 0, "")
+print(result)


### PR DESCRIPTION
- Backtracking
- #136 N과 M(3) 문제 + '**고른 수열은 비내림차순**'이어야 하는 조건
  - 비내림차순 유지 위해 마지막으로 수열에 추가된 숫자 기억
    - `num: Int` 파라미터 추가
    - 반복문의 lower bound 수정 `for n in num...N { ... }`
  - `num`을 증가시키므로 lower bound > upper bound인 경우 발생
    - guard문으로 num이 N 이상이 될 경우 `return`