### PR TITLE
백준 - N과M (3) (15651)

### DIFF
--- a/35주차/NandM3_15631.java
+++ b/35주차/NandM3_15631.java
@@ -1,0 +1,40 @@
+public class NandM3_15651 {
+
+    static int N = 0;
+    static int M = 0;
+
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+        N = scanner.nextInt();
+        M = scanner.nextInt();
+
+        // 순열을 저장할 배열, 재귀 전체가 공유한다.
+        int[] sequence = new int[M];
+        // 출력을 재귀 속에서 하지 않고 마지막에 출력하기 위한 버퍼
+        // 출력을 재귀 속에서 할 경우 타임아웃이 난다..
+        StringBuilder builder = new StringBuilder();
+        for (int i = 1; i <= N; i++) {
+            dfs(i, M, sequence, builder);
+        }
+        System.out.println(builder.toString());
+    }
+
+    private static void dfs(int num, int depth, int[] sequence, StringBuilder builder) {
+        // 순열 현재 위치에 현재 값을 업데이트
+        sequence[M - depth] = num;
+        depth--;
+
+        if (depth == 0) {
+            // 현재 순열 정보를 출력 버퍼에 저장
+            for (int seq : sequence) {
+                builder.append(seq);
+                builder.append(' ');
+            }
+            builder.append('\n');
+        } else {
+            for (int i = 1; i <= N; i++) {
+                dfs(i, depth, sequence, builder);
+            }
+        }
+    }
+}


### PR DESCRIPTION
-  https://github.com/0ofKIM/AlgorithmStudy/pull/132 문제에서 중복 제거하는 로직 제거
- 순열 저장은 전체 재귀 내에서 공유하는 배열을 스택처럼 사용
    - `sequence[depth] = currentNum;`
- 재귀 내에서 매번 결과를 출력하면 timeout, 결과를 출력 버퍼에 저장해 뒀다가 재귀가 끝난 뒤 한번에 출력
    - @0ofKIM [저번에 얘기해주신게](https://github.com/0ofKIM/AlgorithmStudy/pull/132#pullrequestreview-671859048) 이 문제였던것같아요 ㅋㅋ 감사합니다!