### PR TITLE
백준 - N-Queen(9663)

### DIFF
--- a/36주차/김의영/N-Queen.swift
+++ b/36주차/김의영/N-Queen.swift
@@ -1,0 +1,32 @@
+func backTracking(_ list : [Int], _ result: inout Int) {
+    if list.count == n {
+        result += 1
+        return
+    }
+
+    for i in 0..<n {
+        if list.count == 0 { backTracking(list+[i], &result) }
+        else {
+            var isPossible = true
+            for j in 0..<list.count {
+                let cross = (list.count - j)
+                if list[j] == i || list[j] + cross == i || list[j] - cross == i {
+                    isPossible = false
+                    break
+                }
+            }
+
+            if isPossible { backTracking(list+[i], &result) }
+        }
+    }
+}
+
+func solution(_ n : Int ) -> Int {
+    var result = 0
+    backTracking([], &result)
+
+    return result
+}
+
+let n = Int(readLine()!)!
+print(solution(n))


### PR DESCRIPTION
### **BackTracking**
- 행/열 체크
  - 재귀함수 실행 시에 본래의 행에 퀸을 놓는다는 전제이므로 행의 기준은 필요 없음
  - 현재 행의 이전 행들 중에서 같은 열에 퀸이 배치된적이 있는지 확인
- 대각선 체크
  - 두 퀸 사이의 거리를 비교했을 때 행의 증가량과 열의 증가량이 같으면 대각선