### PR TITLE
백준 - 오큰수(17298)

### DIFF
--- a/37주차/김의영/BiggestNumberOnRight.swift
+++ b/37주차/김의영/BiggestNumberOnRight.swift
@@ -1,0 +1,19 @@
+func solution() {
+    let n = Int(readLine()!)!
+    let number = readLine()!.split(separator: " ").map { Int(String($0))! }
+    var indexStack: [Int] = []
+    var result = Array(repeating: "-1", count: n)
+    
+    for i in 0..<n {
+        while !indexStack.isEmpty && number[indexStack.last!] < number[i] {
+            let index = indexStack.popLast()!
+            result[index] = "\(number[i])"
+        }
+        
+        indexStack.append(i)
+    }
+    
+    print(result.joined(separator: " "))
+}
+
+solution()


### PR DESCRIPTION
### **스택**
- 스택을 활용하지 않고 입력으로 주어진 숫자 값만을 비교 대상으로 삼고 완전 탐색을 돌렸을 때에 시간 초과가 발생했다.
- 오큰수를 찾지 못한 값의 index를 저장하는 Stack을 활용하여 접근하여 문제 해결
  - 타임아웃 해결이 힘들어서 블로그를 통해 해결 접근방식 참고

### **변수**
- indexStack : 오큰수를 찾지 못한 값의 index 값을 저장해둘 Stack
- result : 결과값 출력을 위한 Int Array
  - 오큰수가 없을 경우의 -1 을 출력하기 위해 Default Value -1로 result Array 생성

### **로직**
- 현재 입력값(number[i])이 indexStack의 last 값 보다 크다면 last의 오큰수는 number[i]가 된다.
  - 스택에는 오큰수를 찾지 못한 인덱스를 넣어주며 number[i] 보다 크면 pop하고 해당 인덱스의 오큰수를 number[i]로 result 값에 추가한다.
  - number[i]의 오큰수도 찾아야하므로 indexStack에 number[i]의 인덱스 i를 넣어주며 n만큼의 반복문을 마친다.