### PR TITLE
백준 - 회전하는 큐(1021)

### DIFF
--- a/39주차/김의영/RotatingQueue.swift
+++ b/39주차/김의영/RotatingQueue.swift
@@ -3,6 +3,7 @@ import Foundation
 func solution() {
     let numberCount = readLine()!.split(separator: " ").map { Int(String($0))! }[0]
     var shouldFindNumbers = readLine()!.split(separator: " ").map { Int(String($0))! }
+    var firstFindNumber = shouldFindNumbers.first!
     var queue = (1...numberCount).map { $0 }
     var result = 0
     
@@ -20,10 +21,10 @@ func solution() {
     }
     
     while shouldFindNumbers.count > 0 {
-        if queue.first! == shouldFindNumbers.first! {
+        if queue.first! == firstFindNumber {
             pop()
         } else {
-            let shouldFindNumberIndex = queue.firstIndex(of: shouldFindNumbers.first!)!
+            let shouldFindNumberIndex = queue.firstIndex(of: firstFindNumber)!
             if round(CGFloat(queue.count)/2) >= CGFloat(shouldFindNumberIndex+1) {
                 (0..<shouldFindNumberIndex).forEach { _ in
                     moveLeft()

--- a/39주차/김의영/RotatingQueue.swift
+++ b/39주차/김의영/RotatingQueue.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+func solution() {
+    let numberCount = readLine()!.split(separator: " ").map { Int(String($0))! }[0]
+    var shouldFindNumbers = readLine()!.split(separator: " ").map { Int(String($0))! }
+    var queue = (1...numberCount).map { $0 }
+    var result = 0
+    
+    func pop() {
+        queue.removeFirst()
+        shouldFindNumbers.removeFirst()
+    }
+    
+    func moveLeft() {
+        queue.append(queue.removeFirst())
+    }
+    
+    func moveRight() {
+        queue.insert(queue.removeLast(), at: 0)
+    }
+    
+    while shouldFindNumbers.count > 0 {
+        if queue.first! == shouldFindNumbers.first! {
+            pop()
+        } else {
+            let shouldFindNumberIndex = queue.firstIndex(of: shouldFindNumbers.first!)!
+            if round(CGFloat(queue.count)/2) >= CGFloat(shouldFindNumberIndex+1) {
+                //moveLeft
+                (0..<shouldFindNumberIndex).forEach { _ in
+                    moveLeft()
+                    result += 1
+                }
+            } else {
+                (0..<queue.count-shouldFindNumberIndex).forEach { _ in
+                    moveRight()
+                    result += 1
+                }
+            }
+        }
+    }
+    print(result)
+}
+
+solution()

--- a/39주차/김의영/RotatingQueue.swift
+++ b/39주차/김의영/RotatingQueue.swift
@@ -25,7 +25,6 @@ func solution() {
         } else {
             let shouldFindNumberIndex = queue.firstIndex(of: shouldFindNumbers.first!)!
             if round(CGFloat(queue.count)/2) >= CGFloat(shouldFindNumberIndex+1) {
-                //moveLeft
                 (0..<shouldFindNumberIndex).forEach { _ in
                     moveLeft()
                     result += 1


### PR DESCRIPTION
### **큐**
- 링크 : https://www.acmicpc.net/problem/1021
- 스택 문제에 이은 큐 문제
- 왼쪽으로 회전해야 할 지, 오른쪽으로 회전해야 할 지의 우선순위를 정하는 로직에 대한 생각이 필요했다.

### **변수**
numberCount : 큐에 들어갈 숫자 개수
shouldFindNumbers : 찾아야 할 숫자들 (= 뽑아내야 할 숫자들)
queue : 회전 큐
result : 최종 출력 값

### **내부 메서드**
pop() : 큐의 숫자를 뽑아내는 역할 & 뽑아냄과 동시에 souldFindNumbers 값 제거
moveLeft() : 왼쪽으로 한 칸 이동
moveRight() : 오른쪽으로 한 칸 이동

### **로직**
1. 큐의 첫 번째 수와 뽑아내야 할 수의 값이 같으면 pop() 메서드 실행
2. 그렇지 않다면 뽑아내야할 수를 찾을때까지 왼쪽 혹은 오른쪽으로 이동해야하는데, 어떤 방향으로 이동해야 좋을지에 대한 판단 필요
3. **round(CGFloat(queue.count)/2) >= CGFloat(shouldFindNumberIndex+1)** 
    => 큐를 절반으로 나눠 이보다 같거나 위에 있다면 moveLeft, 아래에 있다면 moveRight
4. 해당 횟 수 만큼 move할 때 마다 연산 횟수 (result) 추