### PR TITLE
[백준] 회전하는 큐 (1021)

### DIFF
--- a/40주차/안영진/RollingQueue.java
+++ b/40주차/안영진/RollingQueue.java
@@ -1,0 +1,103 @@
+package me.hellozin.ps.baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Deque;
+import java.util.LinkedList;
+
+public class RollingQueue_1021 {
+
+    static final int LEFT = 0;
+    static final int RIGHT = 1;
+
+    public static void main(String[] args) throws IOException {
+        // ========== get input data ==========
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+
+        String[] firstLine = reader.readLine().split(" ");
+        int queueSize = Integer.parseInt(firstLine[0]);
+        int targetCount = Integer.parseInt(firstLine[1]);
+
+        String[] secondLine = reader.readLine().split(" ");
+        int[] targets = new int[targetCount];
+        for (int i = 0; i < targetCount; i++) {
+            targets[i] = Integer.parseInt(secondLine[i]);
+        }
+        // ========== get input data ==========
+
+        // divide queue for decide effective rolling direction
+        Deque<Integer> leftQueue = new LinkedList<>();
+        Deque<Integer> rightQueue = new LinkedList<>();
+        for (int i = 1; i < queueSize/2 + 1; i++) {
+            leftQueue.add(i);
+        }
+        for (int i = queueSize/2 + 1; i <= queueSize; i++) {
+            rightQueue.add(i);
+        }
+
+        int rollingOperationCount = 0;
+
+        // for each target
+        for (int target : targets) {
+
+            // when left.size == 0 && right.size == 1
+            // look with line 84
+            if (leftQueue.isEmpty()) {
+                leftQueue.offerLast(rightQueue.pollFirst());
+            }
+
+            // rolling
+            if (leftQueue.peekFirst() != target) {
+                // find target located at
+                boolean targetLocatedAtLeftQueue = isTargetLocatedAtLeft(leftQueue, rightQueue, target);
+
+                // decide rolling direction
+                int direction = targetLocatedAtLeftQueue ? LEFT : RIGHT;
+                while (leftQueue.peekFirst() != target) {
+                    rollingQueue(leftQueue, rightQueue, direction);
+                    rollingOperationCount++;
+                }
+            }
+
+            // poll target
+            leftQueue.pollFirst();
+
+            // keep valance between left and right
+            if (leftQueue.size() < rightQueue.size() - 1) {
+                leftQueue.offerLast(rightQueue.pollFirst());
+            }
+        }
+        System.out.println(rollingOperationCount);
+    }
+
+    private static boolean isTargetLocatedAtLeft(Deque<Integer> left, Deque<Integer> right, int target) {
+        // example) left: [12, 15, 2, 3] right: [4, 5, 6, 7]
+        boolean leftQueueContainsBorder = left.peekFirst() > left.peekLast();
+
+        boolean targetLocatedAtLeftQueue = true;
+        if (right.peekFirst() == target) {
+            // if left.size < right.size, left rolling is better even target located at right.
+            targetLocatedAtLeftQueue = true;
+        } else if (leftQueueContainsBorder) {
+            targetLocatedAtLeftQueue = (left.peekFirst() < target) || (target <= left.peekLast());
+        } else {
+            targetLocatedAtLeftQueue = (left.peekFirst() < target) && (target <= left.peekLast());
+        }
+        return targetLocatedAtLeftQueue;
+    }
+
+    private static void rollingQueue(Deque<Integer> left, Deque<Integer> right, int direction) {
+        switch (direction) {
+            case LEFT:
+                right.offerLast(left.pollFirst());
+                left.offerLast(right.pollFirst());
+                break;
+            case RIGHT:
+                left.offerFirst(right.pollLast());
+                right.offerFirst(left.pollLast());
+                break;
+        }
+    }
+
+}

--- a/40주차/안영진/RollingQueue.java
+++ b/40주차/안영진/RollingQueue.java
@@ -42,7 +42,7 @@ public class RollingQueue_1021 {
         for (int target : targets) {
 
             // when left.size == 0 && right.size == 1
-            // look with line 84
+            // look with line 67
             if (leftQueue.isEmpty()) {
                 leftQueue.offerLast(rightQueue.pollFirst());
             }


### PR DESCRIPTION
## 문제

[회전하는 큐](https://www.acmicpc.net/problem/1021)

**요약**

N개의 원소를 가지는 양방향 순환 큐에서 아래 3가지 연산이 가능하다고 할 때,
1. 첫 번째 원소를 뽑아낸다. 이 연산을 수행하면, 원래 큐의 원소가 `a1, ..., ak`이었던 것이 `a2, ..., ak`와 같이 된다.
2. 왼쪽으로 한 칸 이동시킨다. 이 연산을 수행하면, `a1, ..., ak`가 `a2, ..., ak, a1`이 된다.
3. 오른쪽으로 한 칸 이동시킨다. 이 연산을 수행하면, `a1, ..., ak`가 `ak, a1, ..., ak-1`이 된다.

원하는 원소를 뽑아내는데 필요한(1번 연산) 2번, 3번 연산의 수를 구하시요

## 추가설명

의영님 풀이랑 인터넷 풀이를 보다가 흥미로운 점이 보여서 조금 다른 방법으로 풀어보고 싶었어요 😀
- 대부분 풀이에서 큐 내부의 원하는 값 위치를 찾을 때 `queue.indexOf(target)`를 사용
- 이 메소드의 시간복잡도가 `O(N)` (swift랑 java만 확인해봤어요)

실제 문제의 입력 범위로는 거의 차이가 없지만 아래 입력 케이스는 풀이 방법에 따라 실행시간 차이가 상당히 많이 남.
```
input:
100000 100000
100000 99999 99998 ...

elapsed time:
-------------------------
queue.indexOf() | 12578ms
-------------------------
다른 풀이         |    24ms
-------------------------
```

## 풀이

- 중요한 부분은 큐의 회전 방향을 고르는 것.
- 원하는 값이 큐의 중심보다 왼쪽에 있으면 왼쪽으로, 오른쪽에 있으면 오른쪽으로 회전하는 것이 더 빠름
- 큐의 중심을 어떻게 알 수 있을까?
- 자료구조 Deque의 head, tail 추가/삭제 연산이 O(1)인 점을 활용해 큐를 2개(**left**와 **right**)로 나눈다.
- **left**와 **right**의 비율을 잘 유지해주면 원하는 값이 어디에 들었는지 쉽게 알 수 있다.
    - **left**에 없으면 **right**에 있으니 **left**만 검사하면 된다
    - **left**에 경계값이 있는 경우 (ex_ `left: [12, 15, 2], right: [3, 5, 7]`)
	    - `left.first < target || target <= left.last` 가 true 이면 원하는 값이 **left**에 있다.
    - **left**에 경계값이 없는 경우
	    - `left.first < target && target <= left.last` 가 true 이면 원하는 값이 **left**에 있다.
- **target**을 찾은 방향으로 큐를 회전시킨다.