### PR TITLE
문제 제출용 스크립트 추가

### DIFF
--- a/submit-solution.py
+++ b/submit-solution.py
@@ -45,15 +45,16 @@ def check_before_execute(new_absolute_file_path, new_branch_name, commit_message
     _confirm = input("(y/n) :")
     return _confirm
 
+
 def git_checkout_from_master(new_branch_name):
     git_checkout_master_cmd = "git checkout master"
     subprocess.call(git_checkout_master_cmd.split(" "))
 
-    GIT_PULL_MASTER_CMD = "git pull origin master"
-    subprocess.call(GIT_PULL_MASTER_CMD.split(" "))
+    git_pull_master_cmd = "git pull origin master"
+    subprocess.call(git_pull_master_cmd.split(" "))
 
-    GIT_CHECKOUT_CMD = "git checkout -b %s" % (new_branch_name)
-    subprocess.call(GIT_CHECKOUT_CMD.split(" "))
+    git_checkout_cmd = "git checkout -b %s" % (new_branch_name)
+    subprocess.call(git_checkout_cmd.split(" "))
 
 
 def git_add_and_commit(new_absolute_file_path, commit_message):
@@ -86,13 +87,13 @@ author_name = input("작성자 이름: ").replace(" ", "")
 problem_name = input("문제 이름: ").replace(" ", "")
 print("제출할 파일을 선택해주세요.")
 tkinter.Tk().withdraw()
-absoluteFilePath = tkinter.filedialog.askopenfilename(title="제출할 파일을 선택해주세요.")
-print("파일 경로: ", absoluteFilePath)
+absolute_file_path = tkinter.filedialog.askopenfilename(title="제출할 파일을 선택해주세요.")
+print("파일 경로: ", absolute_file_path)
 commit_message = input("커밋메시지: ")
 
-newWeekString, new_directory_name = get_next_directory_name(BASE_DIRECTORY, DIRECTORY_SUFFIX)
-new_branch_name = "feature/%s(%s)-%s" % (author_name, newWeekString, problem_name)
-new_absolute_file_path = get_submit_file_path(absoluteFilePath)
+new_week_string, new_directory_name = get_next_directory_name(BASE_DIRECTORY, DIRECTORY_SUFFIX)
+new_branch_name = "feature/%s(%s)-%s" % (author_name, new_week_string, problem_name)
+new_absolute_file_path = get_submit_file_path(absolute_file_path)
 
 confirm = check_before_execute(new_absolute_file_path, new_branch_name, commit_message)
 if confirm != 'y':
@@ -105,8 +106,8 @@ os.mkdir(new_directory_name)
 print("* [INFO] Create and checkout to branch [ %s ]" % (new_branch_name))
 git_checkout_from_master(new_branch_name)
 
-print("* [INFO] Copy file [ %s ] to [ %s ]" % (absoluteFilePath, new_absolute_file_path))
-shutil.copy(absoluteFilePath, new_absolute_file_path)
+print("* [INFO] Copy file [ %s ] to [ %s ]" % (absolute_file_path, new_absolute_file_path))
+shutil.copy(absolute_file_path, new_absolute_file_path)
 
 print("* [INFO] Git add and commit")
 git_add_and_commit(new_absolute_file_path, commit_message)

--- a/submit-solution.py
+++ b/submit-solution.py
@@ -5,95 +5,111 @@ import re
 import shutil
 import subprocess
 
-# input author name
-authorName = input("작성자 이름: ").replace(" ", "")
-# input problem name
-problemName = input("문제 이름: ").replace(" ", "")
-# input file path to submit
+BASE_DIRECTORY = "./dirs"
+DIRECTORY_SUFFIX = "주차"
+
+
+def get_next_directory_name(base_directory, directory_suffix):
+    directory_pattern_string = "([\d]+)" + directory_suffix
+    directory_pattern = re.compile(directory_pattern_string)
+
+    max_week = 1
+    previous_directories = os.listdir(base_directory)
+    for directory in previous_directories:
+        match = directory_pattern.match(directory)
+        if match:
+            week = int(match.group(1))
+            if week > max_week:
+                max_week = week
+
+    new_week_string = "%s%s" % (max_week + 1, directory_suffix)
+    new_directory_name = "%s/%s" % (base_directory, new_week_string)
+
+    return new_week_string, new_directory_name
+
+
+def get_submit_file_path(absolute_file_path):
+    original_file_name = os.path.basename(absolute_file_path)
+    new_absolute_file_path = "%s/%s" % (new_directory_name, original_file_name)
+
+    return new_absolute_file_path
+
+
+def check_before_execute(new_absolute_file_path, new_branch_name, commit_message):
+    print()
+    print("아래 내용으로 제출하시겠습니까?")
+    print("* 제출할 파일:", new_absolute_file_path)
+    print("* branch:", new_branch_name)
+    print("* commit message", commit_message)
+
+    _confirm = input("(y/n) :")
+    return _confirm
+
+def git_checkout_from_master(new_branch_name):
+    git_checkout_master_cmd = "git checkout master"
+    subprocess.call(git_checkout_master_cmd.split(" "))
+
+    GIT_PULL_MASTER_CMD = "git pull origin master"
+    subprocess.call(GIT_PULL_MASTER_CMD.split(" "))
+
+    GIT_CHECKOUT_CMD = "git checkout -b %s" % (new_branch_name)
+    subprocess.call(GIT_CHECKOUT_CMD.split(" "))
+
+
+def git_add_and_commit(new_absolute_file_path, commit_message):
+    git_add_cmd = "git add %s" % new_absolute_file_path
+    subprocess.call(git_add_cmd.split(" "))
+
+    git_commit_cmd = "git commit -m"
+    commit_message = "'%s'" % commit_message
+
+    git_commit_cmd = git_commit_cmd.split(" ")
+    git_commit_cmd.append(commit_message)
+
+    subprocess.call(git_commit_cmd)
+
+
+def git_push_and_delete_local_branch(new_branch_name):
+    git_push_cmd = "git push origin %s" % (new_branch_name)
+    subprocess.call(git_push_cmd.split(" "))
+
+    # git delete local branch
+    git_checkout_master_cmd = "git checkout master"
+    subprocess.call(git_checkout_master_cmd.split(" "))
+
+    git_delete_local_branch_cmd = "git branch -d %s" % (new_branch_name)
+    subprocess.call(git_delete_local_branch_cmd.split(" "))
+
+
+# input
+author_name = input("작성자 이름: ").replace(" ", "")
+problem_name = input("문제 이름: ").replace(" ", "")
 print("제출할 파일을 선택해주세요.")
 tkinter.Tk().withdraw()
 absoluteFilePath = tkinter.filedialog.askopenfilename(title="제출할 파일을 선택해주세요.")
 print("파일 경로: ", absoluteFilePath)
-# input commit message
-commitMessage = input("커밋메시지: ")
+commit_message = input("커밋메시지: ")
 
-# get most recent directory
-baseDirectory = "."
-previousDirectories = os.listdir(baseDirectory)
+newWeekString, new_directory_name = get_next_directory_name(BASE_DIRECTORY, DIRECTORY_SUFFIX)
+new_branch_name = "feature/%s(%s)-%s" % (author_name, newWeekString, problem_name)
+new_absolute_file_path = get_submit_file_path(absoluteFilePath)
 
-directorySuffix = "주차"
-directoryPatternString = "([\d]+)"+directorySuffix
-directoryPattern = re.compile(directoryPatternString)
-
-maxWeek = 1
-for directory in previousDirectories:
-  match = directoryPattern.match(directory)
-  if match:
-    week = int(match.group(1))
-    if week > maxWeek:
-      maxWeek = week
-
-# get new directory name
-newWeekString = "%s%s" % (maxWeek + 1, directorySuffix)
-newDirectoryName = "%s/%s" % (baseDirectory, newWeekString)
-
-# get new branch name
-newBranchName = "feature/%s(%s)-%s" % (authorName, newWeekString, problemName)
-
-# get new file path
-originalFileName = os.path.basename(absoluteFilePath)
-newAbsoluteFilePath = "%s/%s" % (newDirectoryName, originalFileName)
-
-# check confirm
-print()
-print("아래 내용으로 제출하시겠습니까?")
-print("* 제출할 파일:", newAbsoluteFilePath)
-print("* branch:", newBranchName)
-print("* commit message", commitMessage)
-confirm = input("(y/n) :")
+confirm = check_before_execute(new_absolute_file_path, new_branch_name, commit_message)
 if confirm != 'y':
-  print("취소되었습니다.")
-  exit()
+    print("취소되었습니다.")
+    exit()
 
-# start execute
-# create new directory
-os.mkdir(newDirectoryName)
-print("create new directory [ %s ]" % (newDirectoryName))
+print("* [INFO] Create new directory [ %s ]" % (new_directory_name))
+os.mkdir(new_directory_name)
 
-# create new git branch
-GIT_CHECKOUT_MASTER_CMD = "git checkout master"
-subprocess.call(GIT_CHECKOUT_MASTER_CMD.split(" "))
+print("* [INFO] Create and checkout to branch [ %s ]" % (new_branch_name))
+git_checkout_from_master(new_branch_name)
 
-GIT_PULL_MASTER_CMD = "git pull origin master"
-subprocess.call(GIT_PULL_MASTER_CMD.split(" "))
+print("* [INFO] Copy file [ %s ] to [ %s ]" % (absoluteFilePath, new_absolute_file_path))
+shutil.copy(absoluteFilePath, new_absolute_file_path)
 
-GIT_CHECKOUT_CMD = "git checkout -b %s" % (newBranchName)
-subprocess.call(GIT_CHECKOUT_CMD.split(" "))
+print("* [INFO] Git add and commit")
+git_add_and_commit(new_absolute_file_path, commit_message)
 
-# copy file to new directory
-shutil.copy(absoluteFilePath, newAbsoluteFilePath)
-print("move file [ %s ] to [ %s ]" % (absoluteFilePath, newAbsoluteFilePath))
-
-# git add
-GIT_ADD_CMD = "git add %s" % (newAbsoluteFilePath)
-subprocess.call(GIT_ADD_CMD.split(" "))
-
-# git commit
-GIT_COMMIT_CMD = "git commit -m"
-commitMessage = "'%s'" % (commitMessage)
-
-GIT_COMMIT_CMD = GIT_COMMIT_CMD.split(" ")
-GIT_COMMIT_CMD.append(commitMessage)
-
-subprocess.call(GIT_COMMIT_CMD)
-
-# git push
-GIT_PUSH_CMD = "git push origin %s" % (newBranchName)
-subprocess.call(GIT_PUSH_CMD.split(" "))
-
-# git delete local branch
-GIT_CHECKOUT_MASTER_CMD = "git checkout master"
-subprocess.call(GIT_CHECKOUT_MASTER_CMD.split(" "))
-
-GIT_DELETE_LOCAL_BRANCH_CMD = "git branch -d %s" % (newBranchName)
-subprocess.call(GIT_DELETE_LOCAL_BRANCH_CMD.split(" "))
+print("* [INFO] Git push and delete local branch [ %s ]" % (new_branch_name))
+git_push_and_delete_local_branch(new_branch_name)

--- a/submit-solution.py
+++ b/submit-solution.py
@@ -27,9 +27,11 @@ directoryPattern = re.compile(directoryPatternString)
 
 maxWeek = 1
 for directory in previousDirectories:
-  week = int(directoryPattern.match(directory).group(1))
-  if week > maxWeek:
-    maxWeek = week
+  match = directoryPattern.match(directory)
+  if match:
+    week = int(match.group(1))
+    if week > maxWeek:
+      maxWeek = week
 
 # get new directory name
 newWeekString = "%s%s" % (maxWeek + 1, directorySuffix)

--- a/submit-solution.py
+++ b/submit-solution.py
@@ -1,0 +1,97 @@
+import tkinter
+import tkinter.filedialog
+import os
+import re
+import shutil
+import subprocess
+
+# input author name
+authorName = input("작성자 이름: ").replace(" ", "")
+# input problem name
+problemName = input("문제 이름: ").replace(" ", "")
+# input file path to submit
+print("제출할 파일을 선택해주세요.")
+tkinter.Tk().withdraw()
+absoluteFilePath = tkinter.filedialog.askopenfilename(title="제출할 파일을 선택해주세요.")
+print("파일 경로: ", absoluteFilePath)
+# input commit message
+commitMessage = input("커밋메시지: ")
+
+# get most recent directory
+baseDirectory = "./dirs"
+previousDirectories = os.listdir(baseDirectory)
+
+directorySuffix = "주차"
+directoryPatternString = "([\d]+)"+directorySuffix
+directoryPattern = re.compile(directoryPatternString)
+
+maxWeek = 1
+for directory in previousDirectories:
+  week = int(directoryPattern.match(directory).group(1))
+  if week > maxWeek:
+    maxWeek = week
+
+# get new directory name
+newWeekString = "%s%s" % (maxWeek + 1, directorySuffix)
+newDirectoryName = "%s/%s" % (baseDirectory, newWeekString)
+
+# get new branch name
+newBranchName = "feature/%s(%s)-%s" % (authorName, newWeekString, problemName)
+
+# get new file path
+originalFileName = os.path.basename(absoluteFilePath)
+newAbsoluteFilePath = "%s/%s" % (newDirectoryName, originalFileName)
+
+# check confirm
+print()
+print("아래 내용으로 제출하시겠습니까?")
+print("* 제출할 파일:", newAbsoluteFilePath)
+print("* branch:", newBranchName)
+print("* commit message", commitMessage)
+confirm = input("(y/n) :")
+if confirm != 'y':
+  print("취소되었습니다.")
+  exit()
+
+# start execute
+# create new directory
+os.mkdir(newDirectoryName)
+print("create new directory [ %s ]" % (newDirectoryName))
+
+# create new git branch
+GIT_CHECKOUT_MASTER_CMD = "git checkout master"
+subprocess.call(GIT_CHECKOUT_MASTER_CMD.split(" "))
+
+GIT_PULL_MASTER_CMD = "git pull origin master"
+subprocess.call(GIT_PULL_MASTER_CMD.split(" "))
+
+GIT_CHECKOUT_CMD = "git checkout -b %s" % (newBranchName)
+subprocess.call(GIT_CHECKOUT_CMD.split(" "))
+
+# copy file to new directory
+shutil.copy(absoluteFilePath, newAbsoluteFilePath)
+print("move file [ %s ] to [ %s ]" % (absoluteFilePath, newAbsoluteFilePath))
+
+# git add
+GIT_ADD_CMD = "git add %s" % (newAbsoluteFilePath)
+subprocess.call(GIT_ADD_CMD.split(" "))
+
+# git commit
+GIT_COMMIT_CMD = "git commit -m"
+commitMessage = "'%s'" % (commitMessage)
+
+GIT_COMMIT_CMD = GIT_COMMIT_CMD.split(" ")
+GIT_COMMIT_CMD.append(commitMessage)
+
+subprocess.call(GIT_COMMIT_CMD)
+
+# git push
+GIT_PUSH_CMD = "git push origin %s" % (newBranchName)
+subprocess.call(GIT_PUSH_CMD.split(" "))
+
+# git delete local branch
+GIT_CHECKOUT_MASTER_CMD = "git checkout master"
+subprocess.call(GIT_CHECKOUT_MASTER_CMD.split(" "))
+
+GIT_DELETE_LOCAL_BRANCH_CMD = "git branch -d %s" % (newBranchName)
+subprocess.call(GIT_DELETE_LOCAL_BRANCH_CMD.split(" "))

--- a/submit-solution.py
+++ b/submit-solution.py
@@ -5,7 +5,7 @@ import re
 import shutil
 import subprocess
 
-BASE_DIRECTORY = "./dirs"
+BASE_DIRECTORY = "."
 DIRECTORY_SUFFIX = "주차"
 
 
@@ -74,7 +74,6 @@ def git_push_and_delete_local_branch(new_branch_name):
     git_push_cmd = "git push origin %s" % (new_branch_name)
     subprocess.call(git_push_cmd.split(" "))
 
-    # git delete local branch
     git_checkout_master_cmd = "git checkout master"
     subprocess.call(git_checkout_master_cmd.split(" "))
 
@@ -82,7 +81,6 @@ def git_push_and_delete_local_branch(new_branch_name):
     subprocess.call(git_delete_local_branch_cmd.split(" "))
 
 
-# input
 author_name = input("작성자 이름: ").replace(" ", "")
 problem_name = input("문제 이름: ").replace(" ", "")
 print("제출할 파일을 선택해주세요.")

--- a/submit-solution.py
+++ b/submit-solution.py
@@ -18,7 +18,7 @@ print("파일 경로: ", absoluteFilePath)
 commitMessage = input("커밋메시지: ")
 
 # get most recent directory
-baseDirectory = "./dirs"
+baseDirectory = "."
 previousDirectories = os.listdir(baseDirectory)
 
 directorySuffix = "주차"


### PR DESCRIPTION
문제 풀고 제출할 때 거쳐야되는 과정이 조금 있는데 이게 은근히 귀찮더라구요 ㅋㅋ
간단한 스크립트 추가해봤습니다. 

그런데 맥 & 제 로컬환경 에서만 테스트한거라 다른 환경에서 제대로 동작 안할 확률이 높아요;;
(특히 encoding, 파일 path 지정 등에서 문제생길 확률 다수..)

1. 작성자 이름, 문제 이름, 제출할 파일 선택, 커밋메시지 를 입력받음
2. `N주차`로 만들어진 폴더를 보고 `N+1주차` 폴더 만들 준비
3. (1)에서 입력받은 작성자 이름, 문제 이름으로 branch 이름 결정
4. 파일 복사, 커밋 등을 수행하기 전 확인하는 단계 `(y/n)`
5. `y`를 입력하면 
6. 폴더생성 -> master branch 최신화 -> branch 생성 -> 파일복사 -> commit & push -> 방금만든 local branch 제거

### 주의사항

- 위에서 이야기한 것 처럼 대충 만들어진 스크립트라 버그가 많습니다
- 각 단계들이 transactional 하지 않아서 중간에 실패하는 경우 만들어진 폴더, branch 등은 수동으로 제거해야 합니다 😢
- 파이썬은 그닥 익숙하지 않아서 코드가 지저분합니다 💩